### PR TITLE
fix firefox bug

### DIFF
--- a/lukemadera_autoform-googleplace.html
+++ b/lukemadera_autoform-googleplace.html
@@ -1,6 +1,6 @@
 <template name="afGooglePlace">
   <div class='lm-autoform-google-place-input-cont'>
-    <input type="text" value="{{this.value.fullAddress}}" {{atts}} class='lm-autoform-google-place-input' />
+    <input type="text" value="{{this.value.fullAddress}}" {{atts}} class='lm-autoform-google-place-input' autocomplete="off" />
     <div class='lm-autoform-google-place-predictions {{classes.predictions}}'>
       {{#each predictions}}
         <div class='lm-autoform-google-place-prediction-item {{xDisplay.selected}}'>{{description}}</div>


### PR DESCRIPTION
fixes strange behaviour on at least firefox, when two selects are displayed over each other (one with google maps entrys, one with the last typed inputs in this field)
